### PR TITLE
fix: fail the scan when a requested -conf cannot be written

### DIFF
--- a/main.go
+++ b/main.go
@@ -195,17 +195,19 @@ func runScanCmd(ctx context.Context, opts options) error {
 	default:
 		writeConsole(os.Stdout, ph, consoleRenderer(os.Stdout), opts.tunPingCheck)
 	}
+
+	var confErr error
 	if opts.conf != "" {
-		writeConfFile(opts, ph)
+		confErr = writeConfFile(opts, ph)
 	}
 
 	if opts.noReport {
-		return nil
+		return confErr
 	}
 
 	reportPath := opts.output
 	if reportPath == "" && (opts.best || opts.conf == confStdout) {
-		return nil
+		return confErr
 	}
 	if reportPath == "" {
 		reportPath = fmt.Sprintf("warpscout-report-%s.txt", time.Now().Format("2006-01-02-150405"))
@@ -215,7 +217,7 @@ func runScanCmd(ctx context.Context, opts options) error {
 	} else {
 		fmt.Fprintln(os.Stderr, errPal.dim(fmt.Sprintf("\nFull report written to %s", reportPath)))
 	}
-	return nil
+	return confErr
 }
 
 func showsSpeed(opts options) bool {
@@ -356,11 +358,10 @@ func noEndpointMsg(opts options) string {
 
 const noWorkingMsg = "every matching endpoint was torn down mid-stream"
 
-func writeConfFile(opts options, ph phaseResult) {
+func writeConfFile(opts options, ph phaseResult) error {
 	best, ok := bestOverall(ph)
 	if !ok {
-		fmt.Fprintln(os.Stderr, errPal.fail(noWorkingMsg))
-		return
+		return fmt.Errorf("%s", noWorkingMsg)
 	}
 	// The separator goes to stderr: on a terminal it still splits the config off
 	// the progress lines, and "-conf - > file" stays free of a leading blank line.
@@ -368,11 +369,10 @@ func writeConfFile(opts options, ph phaseResult) {
 		fmt.Fprintln(os.Stderr)
 	}
 	if err := writeConf(opts, best.endpoint, ph.run); err != nil {
-		fmt.Fprintln(os.Stderr, errPal.fail(fmt.Sprintf("failed to write %s: %v", opts.conf, err)))
-		return
+		return fmt.Errorf("failed to write %s: %v", opts.conf, err)
 	}
 	if opts.conf == confStdout {
-		return
+		return nil
 	}
 	fmt.Fprintln(os.Stderr, errPal.dim(fmt.Sprintf("\n%s config for %s written to %s", ph.run.name, best.endpoint, opts.conf)))
 	if outer != nil {
@@ -392,6 +392,7 @@ func writeConfFile(opts options, ph phaseResult) {
 				"  run it with: usque socks -c %s -P %s -s %s%s", opts.conf, port, masqueSNI, h2)))
 		}
 	}
+	return nil
 }
 
 func bestOverall(ph phaseResult) (endpointResult, bool) {

--- a/warp_test.go
+++ b/warp_test.go
@@ -1239,6 +1239,38 @@ func TestShowsSpeed(t *testing.T) {
 	}
 }
 
+func TestWriteConfFile(t *testing.T) {
+	run := protoRun{kindWG, protoWG}
+	ep := endpointResult{endpoint: "1.2.3.4:2408", ok: true, durable: true}
+	working := phaseResult{run, []endpointResult{ep}}
+
+	dir := t.TempDir()
+	conf := filepath.Join(dir, "wg.conf")
+	if err := writeConfFile(options{conf: conf}, working); err != nil {
+		t.Fatalf("writeConfFile: %v", err)
+	}
+	if _, err := os.Stat(conf); err != nil {
+		t.Fatalf("-conf reported success without writing the file: %v", err)
+	}
+
+	missing := filepath.Join(dir, "no-such-dir", "wg.conf")
+	if err := writeConfFile(options{conf: missing}, working); err == nil {
+		t.Error("unwritable -conf path reported success")
+	}
+
+	torn := phaseResult{run, []endpointResult{{endpoint: ep.endpoint, ok: true}}}
+	tornConf := filepath.Join(dir, "torn.conf")
+	switch err := writeConfFile(options{conf: tornConf}, torn); {
+	case err == nil:
+		t.Error("-conf with nothing but torn-down endpoints reported success")
+	case err.Error() != noWorkingMsg:
+		t.Errorf("torn-down run failed with %q, want %q", err, noWorkingMsg)
+	}
+	if _, err := os.Stat(tornConf); err == nil {
+		t.Error("a config was written for a torn-down endpoint")
+	}
+}
+
 func TestReportPingColumns(t *testing.T) {
 	r := endpointResult{
 		endpoint: "1.2.3.4:2408",


### PR DESCRIPTION
Fixes #6.

`writeConfFile` did not return an error: it printed both of its failures to stderr and returned early, so `runScanCmd` returned `nil` and the process exited 0 even though the requested config was never created.

## What changed

`writeConfFile` now returns an error and `runScanCmd` propagates it. Both failures are covered: the write itself, and having no durable endpoint to write a config for.

The error is no longer printed where it happens: `main` already renders every command error through the same `errPal.fail` before `os.Exit(1)`, so keeping both would print the line twice. That also matches `setupScan`, `validateThreshold` and `runRegisterCmd`, which return their errors without printing them.

The failure is held in a local and returned at the end rather than early, so the report file is still written: the scan itself succeeded, only the exit status should change. All three exits after the config step propagate it.

## Out of scope

A failing report write stays non-fatal: it is written unconditionally under a generated name, so making it fatal would change the exit status of runs that never asked for a file. `printBest` still calls `os.Exit(1)` from inside itself on the same condition: same class of problem, separate change.

## Test

`TestWriteConfFile` covers a successful write, an unwritable path, and a run with nothing but torn-down endpoints, asserting the error and that no config file is left behind. The unwritable path is a missing parent directory rather than a read-only one, which root walks straight through. With both `return`s changed back to `nil`, the test fails on both assertions.