### PR TITLE
fix: reject a nonpositive -sample instead of widening the scan

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -8,6 +8,7 @@ import (
 	"net/netip"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -180,6 +181,32 @@ func intFlag(fs *flag.FlagSet, p *int, def int, short, long string) {
 	fs.IntVar(p, long, def, "")
 }
 
+func validateSample(n int) error {
+	if n < 1 {
+		return fmt.Errorf("must be at least 1")
+	}
+	return nil
+}
+
+func intFlagValidate(fs *flag.FlagSet, p *int, def int, short, long string, validate func(int) error) {
+	*p = def
+	set := func(s string) error {
+		n, err := strconv.ParseInt(s, 0, strconv.IntSize)
+		if err != nil {
+			return fmt.Errorf("parse error")
+		}
+		if err := validate(int(n)); err != nil {
+			return err
+		}
+		*p = int(n)
+		return nil
+	}
+	for _, name := range []string{short, long} {
+		fs.Func(name, "", set)
+		fs.Lookup(name).DefValue = strconv.Itoa(def)
+	}
+}
+
 func strFlag(fs *flag.FlagSet, p *string, def, short, long string) {
 	fs.StringVar(p, short, def, "")
 	fs.StringVar(p, long, def, "")
@@ -216,7 +243,7 @@ func setupScanFlags(fs *flag.FlagSet, o *options) {
 	addNetFlags(fs, o)
 	addAWGFlags(fs, o)
 	intFlag(fs, &o.tunnelParallel, defaultTunnelJobs, "jt", "tunnel-jobs")
-	intFlag(fs, &o.perSubnet, 5, "n", "sample")
+	intFlagValidate(fs, &o.perSubnet, 5, "n", "sample", validateSample)
 	fs.IntVar(&o.port, "port", 0, "")
 	strFlag(fs, &o.proto, protoWG, "p", "proto")
 	strFlag(fs, &o.output, "", "o", "output")
@@ -262,7 +289,7 @@ func setupFindJunkFlags(fs *flag.FlagSet, o *options) {
 	addNetFlags(fs, o)
 	addI1GenFlags(fs, o)
 	intFlag(fs, &o.tunnelParallel, defaultTunnelJobs, "jt", "tunnel-jobs")
-	intFlag(fs, &o.perSubnet, findJunkSample, "n", "sample")
+	intFlagValidate(fs, &o.perSubnet, findJunkSample, "n", "sample", validateSample)
 	fs.IntVar(&o.threshold, "threshold", defaultJunkThreshold, "")
 	fs.BoolVar(&o.plain, "plain", false, "")
 	o.proto = protoAWG


### PR DESCRIPTION
Fixes #8.

`expandV4` treats a sample of `<= 0` as "the whole subnet" the sentinel `-full` sets, so `scan -n -1` quietly scanned all 256 addresses of every pool instead of failing.

## What changed

`-sample` is now bounded at 1 by the flag's own parser (`flag.Func`), so a nonpositive value is a usage error: exit status 2 and `invalid value "-1" for flag -n: must be at least 1`, the way `-n abc` already failed. 

This covers both commands that register the flag and every spelling of it. `-full` and the sentinel behind it are untouched, and `-sample 300` still scans all 256 addresses: `expandV4` clamps, and asking for 300 of 256 can only mean all of them.

`intFlagValidate` is not specific to `-sample`; any int flag with a bound can move onto it.

## One behaviour difference

The bound applies per occurrence rather than to the final value: `-n 5 -n 0` is now rejected, which is the point, and `-n 0 -n 5` is rejected too, which is new.

## No test

None of the flag validations in the tree are tested, and a test here would mostly assert that `flag` calls `Set`. Verified by hand on both commands, including the `-target 1.2.3.0/29` repro from the issue.